### PR TITLE
feat: replace implementation with `<Index>` components

### DIFF
--- a/src/app/components/poster-wall.tsx
+++ b/src/app/components/poster-wall.tsx
@@ -23,6 +23,7 @@ const PosterWall = () => {
             list: 'flex flex-row flex-wrap h-full w-full relative -top-6 -left-6',
             item: 'w-1/8 h-1/3',
           }}
+          transformItems={(hits) => hits.sort(() => Math.random() - 0.5)}
         />
       </div>
     </Index>

--- a/src/app/components/poster-wall.tsx
+++ b/src/app/components/poster-wall.tsx
@@ -1,49 +1,45 @@
-import { useEffect, useState } from "react";
-import { Movie } from "../types";
-import { ALGOLIA_INDEX } from "../helpers/algolia";
-
-const getInitialData = async () => {
-  const latestHits = await ALGOLIA_INDEX.search("", {
-    hitsPerPage: 40,
-    attributesToRetrieve: ["poster_path"],
-    filters: "genres:Horror",
-  });
-
-  return latestHits.hits.sort(() => Math.random() - 0.5);
-};
+import { Configure, Hits, Index } from 'react-instantsearch';
+import { Movie } from '../types';
 
 const PosterWall = () => {
-  const [paths, setPaths] = useState<Movie[]>([]); // State to store the fetched data
-
-  useEffect(() => {
-    getInitialData().then((data: any) => {
-      setPaths(data);
-    });
-  }, []);
-
   return (
-    <div
-      className="absolute top-0 left-0 h-screen w-screen z-0"
-      style={{
-        perspective: "1000px",
-        transformStyle: "preserve-3d",
-      }}
-    >
-      <div className="flex flex-row flex-wrap h-full w-full relative -top-6 -left-6">
-        {paths.map((path) => (
-          <div className="w-1/8 h-1/3" key={path.poster_path}>
-            <img
-              src={`https://image.tmdb.org/t/p/w185/${path.poster_path}`}
-              className="w-full h-full object-cover object-top"
-              style={{
-                transform: `skew(-15deg)`,
-              }}
-            />
-          </div>
-        ))}
+    <Index indexName="horror_movies">
+      <Configure
+        hitsPerPage={40}
+        attributesToRetrieve={['poster_path']}
+        filters="genres:Horror"
+      />
+      <div
+        className="absolute top-0 left-0 h-screen w-screen z-0"
+        style={{
+          perspective: '1000px',
+          transformStyle: 'preserve-3d',
+        }}
+      >
+        <div className="flex flex-row flex-wrap h-full w-full relative -top-6 -left-6">
+          <Hits hitComponent={Hit} />
+        </div>
       </div>
-    </div>
+    </Index>
   );
 };
+
+type HitProps = {
+  hit: Movie;
+};
+
+function Hit({ hit }: HitProps) {
+  return (
+    <div className="w-1/8 h-1/3" key={hit.poster_path}>
+      <img
+        src={`https://image.tmdb.org/t/p/w185/${hit.poster_path}`}
+        className="w-full h-full object-cover object-top"
+        style={{
+          transform: `skew(-15deg)`,
+        }}
+      />
+    </div>
+  );
+}
 
 export default PosterWall;

--- a/src/app/components/poster-wall.tsx
+++ b/src/app/components/poster-wall.tsx
@@ -1,5 +1,6 @@
 import { Configure, Hits, Index } from 'react-instantsearch';
 import { Movie } from '../types';
+import { Fragment } from 'react';
 
 const PosterWall = () => {
   return (
@@ -16,9 +17,13 @@ const PosterWall = () => {
           transformStyle: 'preserve-3d',
         }}
       >
-        <div className="flex flex-row flex-wrap h-full w-full relative -top-6 -left-6">
-          <Hits hitComponent={Hit} />
-        </div>
+        <Hits
+          hitComponent={Hit}
+          classNames={{
+            list: 'flex flex-row flex-wrap h-full w-full relative -top-6 -left-6',
+            item: 'w-1/8 h-1/3',
+          }}
+        />
       </div>
     </Index>
   );
@@ -30,7 +35,7 @@ type HitProps = {
 
 function Hit({ hit }: HitProps) {
   return (
-    <div className="w-1/8 h-1/3" key={hit.poster_path}>
+    <Fragment key={hit.poster_path}>
       <img
         src={`https://image.tmdb.org/t/p/w185/${hit.poster_path}`}
         className="w-full h-full object-cover object-top"
@@ -38,7 +43,7 @@ function Hit({ hit }: HitProps) {
           transform: `skew(-15deg)`,
         }}
       />
-    </div>
+    </Fragment>
   );
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,18 +1,29 @@
-import dynamic from "next/dynamic";
+'use client';
 
-const Hero = dynamic(() => import("./components/hero"), {
+import algoliasearch from 'algoliasearch/lite';
+import dynamic from 'next/dynamic';
+import { InstantSearch } from 'react-instantsearch';
+
+const Hero = dynamic(() => import('./components/hero'), {
   ssr: false,
 });
 
-const Search = dynamic(() => import("./search"), {
+const Search = dynamic(() => import('./search'), {
   ssr: false,
 });
+
+const searchClient = algoliasearch(
+  'PVXYD3XMQP',
+  '69636a752c16bee55133304edea993f7'
+);
 
 export default function Home() {
   return (
     <main>
-      <Hero />
-      <Search />
+      <InstantSearch searchClient={searchClient} indexName="horror_movies">
+        <Hero />
+        <Search />
+      </InstantSearch>
     </main>
   );
 }

--- a/src/app/search.tsx
+++ b/src/app/search.tsx
@@ -1,95 +1,79 @@
-"use client";
+'use client';
 
-import cx from "classnames";
-import algoliasearch from "algoliasearch/lite";
-import {
-  Configure,
-  InstantSearch,
-  SearchBox,
-  useSearchBox,
-} from "react-instantsearch";
-import CustomInfiniteHits from "@/app/components/hits";
-import CustomSearchBox from "./components/searchbox";
-import { use, useEffect, useState } from "react";
-import {
-  MagnifyingGlassCircleIcon,
-  MagnifyingGlassIcon,
-} from "@heroicons/react/20/solid";
-import { useShrinkOnScroll } from "./hooks/useShrinkOnScroll";
-import { ALGOLIA_INDEX } from "./helpers/algolia";
-
-const searchClient = algoliasearch(
-  "PVXYD3XMQP",
-  "69636a752c16bee55133304edea993f7"
-);
+import cx from 'classnames';
+import { Index, SearchBox, useInstantSearch } from 'react-instantsearch';
+import { MagnifyingGlassIcon } from '@heroicons/react/20/solid';
+import { useShrinkOnScroll } from './hooks/useShrinkOnScroll';
+import { Movie } from './types';
 
 const Search = () => {
-  const [query, setQuery] = useState("");
   const shrink = useShrinkOnScroll(200);
-  const [allGenres, setAllGenres] = useState<any[]>([]);
   const scrollToEnd = () => {
     window.scrollTo({
       top: 500,
-      behavior: "smooth",
+      behavior: 'smooth',
     });
   };
-
-  const getAllGenres = async () => {
-    const response = await ALGOLIA_INDEX.searchForFacetValues(
-      "genres",
-      "",
-      {}
-    ).then((facet) => {
-      return facet.facetHits;
-    });
-
-    return response;
-  };
-
-  useEffect(() => {
-    getAllGenres().then((data) => {
-      console.log(data);
-      setAllGenres(data);
-    });
-  }, []);
 
   return (
     <div className="relative">
-      <div
-        className={cx(
-          "w-full absolute z-20 flex items-center justify-center top-0 left-0 transition-all duration-500 ease-in-out",
-          shrink ? "" : "-translate-y-24"
-        )}
-      >
-        <div
-          className={cx(
-            "h-full relative transition-[width] duration-500 ease-in-out",
-            shrink ? "w-1/2" : "w-[420px]"
+      <Index indexName="horror_movies">
+        <SearchBox
+          classNames={{
+            root: cx(
+              'w-full absolute z-20 flex items-center justify-center top-0 left-0 transition-all duration-500 ease-in-out',
+              shrink ? '' : '-translate-y-24'
+            ),
+            form: cx(
+              'h-full relative transition-[width] duration-500 ease-in-out',
+              shrink ? 'w-1/2' : 'w-[420px]'
+            ),
+            input:
+              'w-full h-[50px] bg-black rounded-lg shadow-lg left-0 right-0 mx-auto px-4 py-2 ring ring-red-700 focus:outline-none focus:ring-2 focus:border-4 focus:border-red-950',
+          }}
+          submitIconComponent={() => (
+            <MagnifyingGlassIcon className="w-6 h-6 text-red-700 absolute right-4 top-1/2 transform -translate-y-1/2" />
           )}
-        >
-          <input
-            type="text"
-            onClick={scrollToEnd}
-            onChange={(e) => {
-              setQuery(e.target.value);
-            }}
-            className="w-full h-[50px] bg-black rounded-lg shadow-lg left-0 right-0 mx-auto px-4 py-2 ring ring-red-700 focus:outline-none focus:ring-2 focus:border-4 focus:border-red-950"
-          />
-
-          <MagnifyingGlassIcon className="w-6 h-6 text-red-700 absolute right-4 top-1/2 transform -translate-y-1/2" />
-        </div>
-      </div>
-      {allGenres.map((genre) => {
-        return (
-          <InstantSearch searchClient={searchClient} indexName="horror_movies">
-            <Configure query={query} />
-
-            <CustomInfiniteHits title={genre.value} genre={genre.value} />
-          </InstantSearch>
-        );
-      })}
+          onClick={scrollToEnd}
+        />
+        <Categories />
+      </Index>
     </div>
   );
 };
+
+function Categories() {
+  const { results } = useInstantSearch();
+  const rawCategories = (results.hits as Movie[]).reduce<
+    Record<string, Movie[]>
+  >((categories, curr) => {
+    curr.genres.forEach((category) => {
+      // eslint-disable-next-line no-param-reassign
+      (categories[category] ||= []).push(curr);
+    });
+
+    return categories;
+  }, {});
+
+  const categories = Object.entries(rawCategories || {})
+    .sort((a, b) => b[1].length - a[1].length)
+    .slice(0, 5);
+
+  return (
+    <>
+      {categories.map(([category, hits]) => (
+        <>
+          <strong>{category}</strong>
+          <ul>
+            {hits.map((hit) => (
+              <li>{hit.title}</li>
+            ))}
+          </ul>
+          <hr />
+        </>
+      ))}
+    </>
+  );
+}
 
 export default Search;

--- a/src/app/search.tsx
+++ b/src/app/search.tsx
@@ -45,10 +45,10 @@ function Categories() {
   const { results } = useInstantSearch();
   const rawCategories = (results.hits as Movie[]).reduce<
     Record<string, Movie[]>
-  >((categories, curr) => {
-    curr.genres.forEach((category) => {
+  >((categories, movie) => {
+    movie.genres.forEach((category) => {
       // eslint-disable-next-line no-param-reassign
-      (categories[category] ||= []).push(curr);
+      (categories[category] ||= []).push(movie);
     });
 
     return categories;

--- a/src/app/search.tsx
+++ b/src/app/search.tsx
@@ -8,12 +8,6 @@ import { Movie } from './types';
 
 const Search = () => {
   const shrink = useShrinkOnScroll(200);
-  const scrollToEnd = () => {
-    window.scrollTo({
-      top: 500,
-      behavior: 'smooth',
-    });
-  };
 
   return (
     <div className="relative">
@@ -34,7 +28,12 @@ const Search = () => {
           submitIconComponent={() => (
             <MagnifyingGlassIcon className="w-6 h-6 text-red-700 absolute right-4 top-1/2 transform -translate-y-1/2" />
           )}
-          onClick={scrollToEnd}
+          onClick={() => {
+            window.scrollTo({
+              top: 500,
+              behavior: 'smooth',
+            });
+          }}
         />
         <Categories />
       </Index>


### PR DESCRIPTION
This replaces the implementation manipulating the client directly with `<Index>` components instead.

There might be some broken styling (posters, adjustments to make in the search box) but full functionality should be preserved.