### PR TITLE
Add smaller spacing for smaller screen

### DIFF
--- a/src/app/components/hero.tsx
+++ b/src/app/components/hero.tsx
@@ -1,13 +1,8 @@
 "use client";
 
 import cx from "classnames";
-import dynamic from "next/dynamic";
 
 import { useShrinkOnScroll } from "../hooks/useShrinkOnScroll";
-
-const PosterWall = dynamic(() => import("./poster-wall"), {
-  ssr: false,
-});
 
 export default function Hero() {
   const shrink = useShrinkOnScroll(200);
@@ -15,18 +10,10 @@ export default function Hero() {
   return (
     <section
       className={cx(
-        "h-[600px] grid place-items-center relative z-10 overflow-hidden transition-height duration-500 ease-in-out"
+        "h-[400px] 3xl:h-[600px] grid place-items-center relative z-10 overflow-hidden transition-height duration-500 ease-in-out"
       )}
     >
-      <PosterWall />
-
-      <header
-        className="h-[600px] w-full grid place-items-center relative z-10 overflow-hidden"
-        style={{
-          background:
-            "linear-gradient(180deg, rgba(20,20,20,0.8) 0%, rgba(20,20,20,1) 70%,  rgba(20,20,20,1) 100%)",
-        }}
-      >
+      <header className="h-[400px] 3xl:h-[600px] w-full grid place-items-center relative z-10 overflow-hidden">
         <h1 className="sr-only">Horror Movies Database</h1>
         <img
           src="/SpookyMovieSearch.png"

--- a/src/app/components/poster-wall.tsx
+++ b/src/app/components/poster-wall.tsx
@@ -16,20 +16,20 @@ export default function PosterWall() {
         attributesToRetrieve={['poster_path']}
         filters="genres:Horror"
       />
-      <div
-        className="absolute top-0 left-0 h-screen w-screen z-0"
-        style={{
-          perspective: '1000px',
-          transformStyle: 'preserve-3d',
-        }}
-      >
+      <div className="poster-wall-container absolute top-0 left-0 w-screen z-[5]">
         <Hits
           hitComponent={Hit}
           classNames={{
-            list: 'flex flex-row flex-wrap h-full w-full relative -top-6 -left-6',
-            item: 'w-1/8 h-1/3',
+            list: 'flex flex-row flex-wrap w-full relative',
+            item: '',
           }}
-          transformItems={(hits) => shuffle(hits, salt)}
+          transformItems={(hits) => shuffle(hits, salt).slice(0, 16)}
+        />
+        <div
+          className="absolute inset-0 w-full h-full pointer-events-none"
+          style={{
+            background: 'linear-gradient(180deg, rgba(20,20,20,0.8) 0%, rgba(20,20,20,1) 70%, rgba(20,20,20,1) 100%)',
+          }}
         />
       </div>
     </Index>
@@ -43,13 +43,12 @@ type HitProps = {
 function Hit({ hit }: HitProps) {
   return (
     <Fragment key={hit.poster_path}>
-      <img
-        src={`https://image.tmdb.org/t/p/w185/${hit.poster_path}`}
-        className="w-full h-full object-cover object-top"
-        style={{
-          transform: `skew(-15deg)`,
-        }}
-      />
+      <div style={{ aspectRatio: '2/3', width: '12.5vw' }}>
+        <img
+          src={`https://image.tmdb.org/t/p/w185/${hit.poster_path}`}
+          className="w-full h-full object-cover object-top"
+        />
+      </div>
     </Fragment>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -28,6 +28,10 @@ const Hero = dynamic(() => import("./components/hero"), {
   ssr: false,
 });
 
+const PosterWall = dynamic(() => import("./components/poster-wall"), {
+  ssr: false,
+});
+
 const searchClient = algoliasearch(
   "PVXYD3XMQP",
   "69636a752c16bee55133304edea993f7"
@@ -94,7 +98,8 @@ function Search() {
   }, [selectedMovie]);
 
   return (
-    <main>
+    <main className="relative">
+      <PosterWall />
       <Hero />
       <Index indexName={indexName}>
         <div className={cx("relative mih-screen")}>
@@ -230,13 +235,13 @@ function AllMovies({ onSelect, headerHeight }: AllMoviesProps) {
   const { hits, sentinelRef, isLoading } = useInfinitelyScrolledHits();
 
   return (
-    <div className="mb-8 py-8">
+    <div className="mb-4 3xl:mb-8 py-4 3xl:py-8">
       {/* <MoviesHeading headerHeight={headerHeight}>All Movies</MoviesHeading> */}
 
       <div className="mx-auto max-w-full overflow-hidden sm:px-6 lg:px-8">
         <h2 className="sr-only">Horror Movies List</h2>
 
-        <ul className="overflow-scroll gap-4 scrollbar-hide flex py-12">
+        <ul className="overflow-scroll gap-4 scrollbar-hide flex py-6 3xl:py-12">
           {hits.map((hit) => {
             return (
               <li key={hit.objectID} onClick={() => onSelect?.(hit)}>
@@ -281,7 +286,7 @@ function CategorizedMovies({ onSelect, headerHeight }: CategorizedMoviesProps) {
   return (
     <div className="relative">
       {categories.map((category) => (
-        <div className="mb-8 py-8" key={category}>
+        <div className="mb-4 3xl:mb-8 py-4 3xl:py-8" key={category}>
           <MoviesHeading headerHeight={headerHeight}>{category}</MoviesHeading>
 
           <div className="mx-auto max-w-full overflow-hidden sm:px-6 lg:px-8">
@@ -304,7 +309,7 @@ function MovieCategory({ onSelect }: MovieCategoryProps) {
   const { hits, sentinelRef, isLoading } = useInfinitelyScrolledHits();
 
   return (
-    <ul className="overflow-scroll gap-4 scrollbar-hide flex py-12">
+    <ul className="overflow-scroll gap-4 scrollbar-hide flex py-6 3xl:py-12">
       {hits.map((hit) => {
         return (
           <li

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,6 +8,9 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      screens: {
+        '3xl': '2560px',
+      },
       backgroundImage: {
         "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
         "gradient-conic":


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/c3b060fd-06d2-40bd-b672-e3ef075632ef" /> | <img width="1920" height="1199" alt="image" src="https://github.com/user-attachments/assets/968642fe-6883-4564-84ae-edccc8bcaabb" /> |

Display on small laptop screen (15" like I have) had the search results below the fold, preventing me seeing the result. I reduced the spacing (unless you're on a big screen).

I also changed the way the poster wall displayed its results; rather than displaying 200 of them but hiding most of the, it only display 16 of them, in an absolutely positioned element at the top of the page. It still has the same nice gradient to progressively hide them.

Maybe the most opinionated change is that I removed the skewing effect on the posters, because it didn't align well (I always had a hole on the right), and I find that having them straight isn't so bad. WDYT?

