### PR TITLE
Add .eslintrc.json config for linting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}


### PR DESCRIPTION
This adds an ESLint config file. Without it, Next kept asking me to configure the linting but never actually linted anything, so that might be why the build was failing.